### PR TITLE
Update easy_admin.yaml

### DIFF
--- a/config/packages/easy_admin.yaml
+++ b/config/packages/easy_admin.yaml
@@ -25,7 +25,7 @@ easy_admin:
             edit:
                 fields:
                     - { property: 'conference' }
-                    - { property: 'createdAt', type: datetime, type_options: { attr: { readonly: true } } }
+                    - { property: 'createdAt', type: datetime, type_options: { attr: { readonly: true }, disabled: true } }
                     - 'author'
                     - { property: 'state' }
                     - { property: 'email', type: 'email' }


### PR DESCRIPTION
The "readonly" option does not change the "createdAt" field into a read-only field, the "disabled" option has to be used.